### PR TITLE
Hotfix update career game migration fails caused by active record mod…

### DIFF
--- a/db/migrate/20190426020304_add_primary_key_id_to_careers_games.rb
+++ b/db/migrate/20190426020304_add_primary_key_id_to_careers_games.rb
@@ -1,0 +1,5 @@
+class AddPrimaryKeyIdToCareersGames < ActiveRecord::Migration[5.1]
+  def change
+    add_column :careers_games, :id, :primary_key, null: false, unique: true, auto_increment: true
+  end
+end


### PR DESCRIPTION
…el do not allow to update record without primary key