### PR TITLE
Exclude the CSRF Token from the API v1 to make it support with the ol…

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class ApiController < ActionController::Base
+  protect_from_forgery with: :null_session
   before_action :http_basic_authentication
 
   around_action :rescue_with_check_api_docs


### PR DESCRIPTION
This pull request excludes the CSRF Token authentication from the API v1 to make it support the old version of the TreyVisay mobile app.